### PR TITLE
Implement CreateRelease on ReleaseCreator

### DIFF
--- a/src/create/main.go
+++ b/src/create/main.go
@@ -24,7 +24,12 @@ func main() {
 
 	versionDataPath := filepath.Join(releaseDir, "VERSION")
 
-	createRelease.CreateRelease(imageName, releaseDir, tarballPath, imageTagPath, versionDataPath, outputDir)
+	releaseCreator := new(createRelease.ReleaseCreator)
+	err = releaseCreator.CreateRelease(imageName, releaseDir, tarballPath, imageTagPath, versionDataPath, outputDir)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
+	}
 }
 
 func parseArgs() (string, string, error) {


### PR DESCRIPTION
We'd like to create a new struct ReleaseCreator to implement CreateRelease function, and modify the error case by letting the caller to handle the error.

Signed-off-by: Dave Walter <dwalter@pivotal.io>